### PR TITLE
Fix finding flickable

### DIFF
--- a/Opal/Tabs/TabItem.qml
+++ b/Opal/Tabs/TabItem.qml
@@ -58,10 +58,10 @@ SilicaControl {
         }
 
         if (!flickable) {
-            for (var child in children) {
-                if (child.hasOwnProperty('maximumFlickVelocity') &&
-                        !child.hasOwnProperty('__silica_hidden_flickable')) {
-                    flickable = child
+            for (var i=0; i<contents.length; i++) {
+                if (contents[i].hasOwnProperty('maximumFlickVelocity') &&
+                        !contents[i].hasOwnProperty('__silica_hidden_flickable')) {
+                    flickable = contents[i]
                     break
                 }
             }


### PR DESCRIPTION
Currently, when `flickable` property is not manually specified in TabItem, pulley menu layout (and possibly other things) breaks. To fix, two things were needed to be changed:
1. Traditional index-based loop is now used instead of for...in loop. It did not work otherwise so I had to change it. Possibly the answer to why can be found [here](https://stackoverflow.com/questions/500504/why-is-using-for-in-for-array-iteration-a-bad-idea) or [here](https://stackoverflow.com/questions/5269757/why-is-javascripts-for-in-loop-not-recommended-for-arrays).
2. Instead of iterating through `children`, `contents` iteration is now used. That's because `contents` is the default property and flickable is placed there.