### PR TITLE
Fix tabs caching

### DIFF
--- a/Opal/Tabs/TabItem.qml
+++ b/Opal/Tabs/TabItem.qml
@@ -6,8 +6,8 @@
 //@ Original copyright notices are listed above.
 
 import QtQuick 2.0
+import QtQml.Models 2.2
 import Sailfish.Silica 1.0
-import "private/Util.js" as Util
 
 // WARNING possible future issue: this component uses private __silica_page.isPortrait
 


### PR DESCRIPTION
I noticed that Opal.Tabs tabs are slower to load compared to ones found in Silica package. I tried to change stuff to find a fix, and importing QtQml.Models 2.2 in TabItem.qml did the trick. There seems to be some logic used for caching recent tabs, so this PR fixes it, making tabs faster to load.

As a bonus Util.js import is removed because it is unused (even in the original Silica package).