### PR TITLE
Allow specifying a source by URL and allow using a QML ListModel or another QAbstractListModel-based model

### DIFF
--- a/Opal/Tabs/Tab.qml
+++ b/Opal/Tabs/Tab.qml
@@ -12,4 +12,5 @@ QtObject {
     property string icon
 
     default property Component body
+    property url source
 }

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -108,6 +108,7 @@ PagedView {
         property bool loading: Qt.application.active && isCurrentItem && status === /*Animated*/Loader.Loading
 
         sourceComponent: model.modelData.body
+        source: model.modelData.source
         asynchronous: true
 
         width: item ? item.implicitWidth : root.contentItem.width

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -107,8 +107,8 @@ PagedView {
 
         property bool loading: Qt.application.active && isCurrentItem && status === /*Animated*/Loader.Loading
 
-        sourceComponent: model.modelData.body
-        source: model.modelData.source
+        sourceComponent: model.modelData ? model.modelData.body : model.body
+        source: model.modelData ? model.modelData.source : model.source
         asynchronous: true
 
         width: item ? item.implicitWidth : root.contentItem.width


### PR DESCRIPTION
I needed to implement dynamic tabs loading in my app. I found that it could actually be easier to specify the tab item source by URL instead of a Component. This PR adds support for this.

Additionally, I found that it is easier to put a simple QML ListModel for the `model` property for loading tabs dynamically. Current code requires the data to be accessable from `modelData` property (which is the case for current system used, for example, in gallery). This PR keeps this but uses properties directly from `model` if `modelData` doesn't work.