### PR TITLE
Allow using a generic tab component/source

### DIFF
--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -111,7 +111,7 @@ PagedView {
         property bool loading: Qt.application.active && isCurrentItem && status === /*Animated*/Loader.Loading
 
         // this is needed for accessing model and index from the component
-        property var tabModel: model.modelData || model
+        property var tabModel: !!(model.modelData || model)
         property int tabIndex: index
 
         property bool _haveSource: tabModel.body || tabModel.source

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -111,7 +111,7 @@ PagedView {
         property bool loading: Qt.application.active && isCurrentItem && status === /*Animated*/Loader.Loading
 
         // this is needed for accessing model and index from the component
-        property var tabModel: !!(model.modelData || model)
+        property var tabModel: model.modelData || model
         property int tabIndex: index
 
         property bool _haveSource: tabModel.body || tabModel.source

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -28,6 +28,9 @@ PagedView {
     property alias tabBarItem: tabBarLoader.item
     property real tabBarHeight: tabBarItem && tabBarVisible ?
                                     tabBarItem.height : 0
+    
+    property Component tabComponent
+    property url tabSource
 
     property real yOffset: currentItem && currentItem._yOffset || 0
     property bool _headerBackgroundVisible: true
@@ -107,8 +110,13 @@ PagedView {
 
         property bool loading: Qt.application.active && isCurrentItem && status === /*Animated*/Loader.Loading
 
-        sourceComponent: model.modelData ? model.modelData.body : model.body
-        source: model.modelData ? model.modelData.source : model.source
+        // this is needed for accessing model and index from the component
+        property var tabModel: model.modelData || model
+        property int tabIndex: index
+
+        property bool _haveSource: tabModel.body || tabModel.source
+        sourceComponent: _haveSource ? tabModel.body : tabComponent
+        source: _haveSource ? tabModel.source : tabSource
         asynchronous: true
 
         width: item ? item.implicitWidth : root.contentItem.width


### PR DESCRIPTION
This is only used if no explicit tab body/source was provided. Additional tabModel and tabIndex properties are exposed to it since there is no other way of accessing the model data or the index from it.

Example usage: configurable chat folders in a messaging application. With this change, you could even use a generic QAbstractListModel subclass with name, icon and other tab elements exposed, as well as additional properties to be passed to the view delegate configured using tabComponent/tabSource, from which it would be accessible using `tabModel.<property>`. If the developer would like to also add another non-generic tab (for example, Settings), it would not be too hard - all that would be needed is to explicitly pass a custom body/source.