### PR TITLE
Support changing icon source size, color and highlight color

### DIFF
--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -29,7 +29,7 @@ PagedView {
     property real tabBarHeight: tabBarItem && tabBarVisible ?
                                     tabBarItem.height : 0
 
-    property alias tabIcon: tabIconProxy
+    property alias tabIcons: tabIconProxy
 
     property real yOffset: currentItem && currentItem._yOffset || 0
     property bool _headerBackgroundVisible: true

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -31,6 +31,7 @@ PagedView {
 
     property size defaultTabIconSourceSize
     property color defaultTabIconColor
+    property color defaultTabIconHighlightColor
 
     property real yOffset: currentItem && currentItem._yOffset || 0
     property bool _headerBackgroundVisible: true
@@ -68,6 +69,7 @@ PagedView {
             model: root.model
             defaultIconSourceSize: defaultTabIconSourceSize
             defaultIconColor: defaultTabIconColor
+            defaultIconHighlightColor: defaultTabIconHighlightColor
         }
     }
 

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -1,5 +1,5 @@
 //@ This file is part of Opal.Tabs.
-//@ SPDX-FileCopyrightText: 2024 Mirian Margiani
+//@ SPDX-FileCopyrightText: 2026 roundedrectangle, 2024 Mirian Margiani
 //@ SPDX-FileCopyrightText: Copyright (C) 2019 Jolla Ltd.
 //@ SPDX-FileCopyrightText: Copyright (C) 2020 Open Mobile Platform LLC.
 //@ SPDX-License-Identifier: GPL-3.0-or-later

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -29,6 +29,9 @@ PagedView {
     property real tabBarHeight: tabBarItem && tabBarVisible ?
                                     tabBarItem.height : 0
 
+    property size defaultTabIconSourceSize
+    property color defaultTabIconColor
+
     property real yOffset: currentItem && currentItem._yOffset || 0
     property bool _headerBackgroundVisible: true
 
@@ -63,6 +66,8 @@ PagedView {
 
         TabBar {
             model: root.model
+            defaultIconSourceSize: defaultTabIconSourceSize
+            defaultIconColor: defaultTabIconColor
         }
     }
 

--- a/Opal/Tabs/TabView.qml
+++ b/Opal/Tabs/TabView.qml
@@ -29,9 +29,7 @@ PagedView {
     property real tabBarHeight: tabBarItem && tabBarVisible ?
                                     tabBarItem.height : 0
 
-    property size defaultTabIconSourceSize
-    property color defaultTabIconColor
-    property color defaultTabIconHighlightColor
+    property alias tabIcon: tabIconProxy
 
     property real yOffset: currentItem && currentItem._yOffset || 0
     property bool _headerBackgroundVisible: true
@@ -62,14 +60,18 @@ PagedView {
         property int _ctxBottomMargin: _tabBarIsTop ? 0 : tabBarHeight
     }
 
+    TabIconProxy {
+        id: tabIconProxy
+    }
+
     Component {
         id: tabBarComponent
 
         TabBar {
             model: root.model
-            defaultIconSourceSize: defaultTabIconSourceSize
-            defaultIconColor: defaultTabIconColor
-            defaultIconHighlightColor: defaultTabIconHighlightColor
+            defaultIconSourceSize: tabIconProxy.sourceSize
+            defaultIconColor: tabIconProxy.color
+            defaultIconHighlightColor: tabIconProxy.highlightColor
         }
     }
 

--- a/Opal/Tabs/private/TabBar.qml
+++ b/Opal/Tabs/private/TabBar.qml
@@ -51,9 +51,11 @@ SilicaControl {
     property string iconRole: "icon"
     property string iconSourceSizeRole: "iconSourceSize"
     property string iconColorRole: "iconColor"
+    property string iconHighlightColorRole: "iconHighlightColor"
 
     property size defaultIconSourceSize
     property color defaultIconColor
+    property color defaultIconHighlightColor
 
     height: flickable.height
 
@@ -143,6 +145,7 @@ SilicaControl {
                     icon.source: model[root.iconRole] || ""
                     icon.sourceSize: model[root.iconSourceSizeRole] || defaultIconSourceSize
                     icon.color: model[root.iconColorRole] || defaultIconColor
+                    icon.highlightColor: model[root.iconHighlightColorRole] || defaultIconHighlightColor
                     count: model[root.countRole] || ""
                 }
             }

--- a/Opal/Tabs/private/TabBar.qml
+++ b/Opal/Tabs/private/TabBar.qml
@@ -143,10 +143,30 @@ SilicaControl {
                     title: model[root.titleRole] || ""
                     description: model[root.descriptionRole] || ""
                     icon.source: model[root.iconRole] || ""
-                    icon.sourceSize: model[root.iconSourceSizeRole] || defaultIconSourceSize
-                    icon.color: model[root.iconColorRole] || defaultIconColor
-                    icon.highlightColor: model[root.iconHighlightColorRole] || defaultIconHighlightColor
                     count: model[root.countRole] || ""
+
+                    property var suggestedIconSourceSize: model[root.iconSourceSize] || root.defaultIconSourceSize
+                    property var suggestedIconColor: model[root.iconColorRole] || root.defaultIconColor
+                    property var suggestedIconHighlightColor: model[root.iconHighlightColorRole] || root.defaultIconHighlightColor
+                    
+                    Binding {
+                        target: icon
+                        property: 'sourceSize'
+                        value: suggestedIconSourceSize
+                        when: !!suggestedIconSourceSize
+                    }
+                    Binding {
+                        target: icon
+                        property: 'color'
+                        value: suggestedIconColor
+                        when: !!suggestedIconColor
+                    }
+                    Binding {
+                        target: icon
+                        property: 'highlightColor'
+                        value: suggestedIconHighlightColor
+                        when: !!suggestedIconHighlightColor
+                    }
                 }
             }
         }

--- a/Opal/Tabs/private/TabBar.qml
+++ b/Opal/Tabs/private/TabBar.qml
@@ -1,5 +1,5 @@
 //@ This file is part of Opal.Tabs.
-//@ SPDX-FileCopyrightText: 2024 Mirian Margiani
+//@ SPDX-FileCopyrightText: 2026 roundedrectangle, 2024 Mirian Margiani
 //@ SPDX-FileCopyrightText: Copyright (C) 2020 Open Mobile Platform LLC.
 //@ SPDX-License-Identifier: GPL-3.0-or-later
 //@ Original license: BSD-3-Clause (see separate license file SILICA-LICENSE)

--- a/Opal/Tabs/private/TabBar.qml
+++ b/Opal/Tabs/private/TabBar.qml
@@ -49,6 +49,11 @@ SilicaControl {
     property string descriptionRole: "description"
     property string countRole: "count"
     property string iconRole: "icon"
+    property string iconSourceSizeRole: "iconSourceSize"
+    property string iconColorRole: "iconColor"
+
+    property size defaultIconSourceSize
+    property color defaultIconColor
 
     height: flickable.height
 
@@ -136,6 +141,8 @@ SilicaControl {
                     title: model[root.titleRole] || ""
                     description: model[root.descriptionRole] || ""
                     icon.source: model[root.iconRole] || ""
+                    icon.sourceSize: model[root.iconSourceSizeRole] || defaultIconSourceSize
+                    icon.color: model[root.iconColorRole] || defaultIconColor
                     count: model[root.countRole] || ""
                 }
             }

--- a/Opal/Tabs/private/TabIconProxy.qml
+++ b/Opal/Tabs/private/TabIconProxy.qml
@@ -1,0 +1,11 @@
+//@ This file is part of Opal.Tabs.
+//@ SPDX-FileCopyrightText: 2026 roundedrectangle
+//@ SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick 2.0
+
+QtObject {
+    property size sourceSize
+    property color color
+    property color highlightColor
+}


### PR DESCRIPTION
This is useful when using non-Silica icons. Silica icons (`image://theme/icon-...`) are always sized and colored properly, while simple file icons (`/usr/share/harbour-myapp/images/icon-m-custom-icon.svg`) aren't. This pull request allows to fix this issue by providing a default icon source size, color and highlight color, for example:

```qml
TabView {
    defaultTabIconSourceSize: Qt.size(Theme.iconSizeMedium, Theme.iconSizeMedium)
    defaultTabIconColor: Theme.primaryColor
}
```

Well, coloring is not really a big issue since Silica's `Icon` usually recolors the icon as intended, but that could be used for something else, for example if the app has a custom background instead of the default blurred background.